### PR TITLE
Add a devcontainer descriptor

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,12 @@
+{
+    "name": "java",
+    "image": "mcr.microsoft.com/devcontainers/java:17",
+
+    "features": {
+        "ghcr.io/devcontainers/features/java:1": {
+			"version": "none",
+			"installMaven": "true",
+			"mavenVersion": "3.9.6"
+		}
+    }
+}


### PR DESCRIPTION
**Purpose :**

Describe a dev environment with all the tooling needed to compile test and develop the package. Each developer could launch this dev environment and have a proper container or cloud resource correctly configured.

**Proposal :** 

Use devcontainer standard to describe a container with the following requirements :
- JDK 17 installed
- Maven 3.9.6 installed
- VSCode java plugin installation if VSCode is used

Devcontainer is compatible with VSCode, Intellij or CodeSpaces (Github).