### PR TITLE
release-please - skip pr for forked repos (github_token permissions)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -27,7 +27,9 @@ jobs:
     outputs:
       release_created: ${{ steps.release-please.outputs.release_created }}
       tag_name: ${{ steps.release-please.outputs.tag_name }}
-    if: github.repository_owner == 'OKDP' && github.event.pull_request.merged == true
+    # Skip the release process in the fork
+    # The pull request should come from the same repo (github_token from the fork does not have write permissions)
+    if: github.repository_owner == 'OKDP' && github.event.pull_request.merged == true && github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - uses: google-github-actions/release-please-action@v4
         id: release-please


### PR DESCRIPTION
Skip release-please process for PRs coming from the forks to prevent pipeline failure:

- The pull request should come from the upstream repository (Branches and PRs should be in the same OKDP repo).
- Actually, GITHUB_TOKEN from the fork does not have write permissions on the upstream repository (OKDP repo)
