### PR TITLE
Option to choose the id from the JWT used for identification inside spark UI and spark history (default is email)

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ The filter relies on the spark [spark.ui.filters](https://spark.apache.org/docs/
 | `cookie-max-age-minutes`   | `AUTH_COOKE_MAX_AGE_MINUTES`  | 12 * 60 | The maximum spark-cookie cookie duration in minutes                                                                                                                                                                                                            |
 | `cookie-cipher-secret-key` | `AUTH_COOKIE_ENCRYPTION_KEY`  |    -    | Cookie encryption key</br> Can be generated using: `openssl enc -aes-128-cbc -k <PASS PHRASE> -P -md sha1 -pbkdf2`                                                                                                                                             |
 | `cookie-is-secure`         | `AUTH_COOKE_IS_SECURE`        |  true   | When enabled, the cookie is transmitted over a secure connection only (HTTPS).</br> Disable the option if your run with a non secure connection (HTTP)                                                                                                         |
+| `user-id`         | `AUTH_USER_ID`        |  email   | * `email`: set the id seen by spark acls as the email filled in the access token. </br> * `sub`: set the id seen by spark acls as the sub filled in the access token.                                                                                                          |
 
 > [!NOTE]
 > 1. `issuer-uri` property or `AUTH_ISSUER_URI` env variable
@@ -166,6 +167,7 @@ spark.io.okdp.spark.authc.OidcAuthFilter.param.scope=<scope>
 spark.io.okdp.spark.authc.OidcAuthFilter.param.cookie-max-age-minutes=480
 spark.io.okdp.spark.authc.OidcAuthFilter.param.cookie-cipher-secret-key=<cookie-cipher-secret-key>
 spark.io.okdp.spark.authc.OidcAuthFilter.param.cookie-is-secure=<true|false>
+spark.io.okdp.spark.authc.OidcAuthFilter.param.user-id=<sub|email>
 ```
 
 Or during the job submission like the following:
@@ -180,6 +182,7 @@ spark-submit  --conf spark.ui.filters=io.okdp.spark.authc.OidcAuthFilter \
 --conf spark.io.okdp.spark.authc.OidcAuthFilter.param.cookie-max-age-minutes=480    \
 --conf spark.io.okdp.spark.authc.OidcAuthFilter.param.cookie-cipher-secret-key=<cookie-cipher-secret-key> \
 --conf spark.io.okdp.spark.authc.OidcAuthFilter.param.cookie-is-secure=<true|false>  \
+--conf spark.io.okdp.spark.authc.OidcAuthFilter.param.user-id=<sub|email>  \
 --class ...
 ```
 

--- a/src/main/java/io/okdp/spark/authc/config/Constants.java
+++ b/src/main/java/io/okdp/spark/authc/config/Constants.java
@@ -63,6 +63,9 @@ public interface Constants {
   /** Use PKCE (true|false|auto) */
   String AUTH_USE_PKCE = "use-pkce";
 
+  /** The user id wich will be extracted from the access token (EMAIL|SUB) */
+  String AUTH_USER_ID = "user-id";
+
   /** The cookie encryption key parameter name */
   String AUTH_COOKIE_ENCRYPTION_KEY = "cookie-cipher-secret-key";
 

--- a/src/main/java/io/okdp/spark/authc/config/HttpSecurityConfig.java
+++ b/src/main/java/io/okdp/spark/authc/config/HttpSecurityConfig.java
@@ -16,12 +16,17 @@
 
 package io.okdp.spark.authc.config;
 
+import static java.time.Instant.now;
 import static java.util.Arrays.stream;
+import static java.util.Date.from;
 
+import io.okdp.spark.authc.model.AccessToken;
+import io.okdp.spark.authc.model.PersistedToken;
 import io.okdp.spark.authc.provider.AuthProvider;
 import io.okdp.spark.authc.provider.SessionStore;
 import io.okdp.spark.authc.provider.impl.DefaultAuthorizationCodeAuthProvider;
 import io.okdp.spark.authc.provider.impl.PKCEAuthorizationCodeAuthProvider;
+import io.okdp.spark.authc.utils.TokenUtils;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -60,6 +65,16 @@ public class HttpSecurityConfig {
   public HttpSecurityConfig sessionStore(SessionStore sessionStore) {
     this.sessionStore = sessionStore;
     return this;
+  }
+
+  public PersistedToken toPersistedToken(AccessToken token) {
+    return PersistedToken.builder()
+        .userInfo(TokenUtils.userInfo(token.accessToken()))
+        .refreshToken(token.refreshToken())
+        .expiresIn(token.expiresIn())
+        .expiresAt(from(now().plusSeconds(token.expiresIn())))
+        .identityProvider(oidcConfig().identityProvider())
+        .build();
   }
 
   /** Configure the auth provider */

--- a/src/main/java/io/okdp/spark/authc/model/AccessToken.java
+++ b/src/main/java/io/okdp/spark/authc/model/AccessToken.java
@@ -16,12 +16,8 @@
 
 package io.okdp.spark.authc.model;
 
-import static java.time.Instant.now;
-import static java.util.Date.from;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.okdp.spark.authc.utils.TokenUtils;
 import lombok.Data;
 import lombok.experimental.Accessors;
 
@@ -47,13 +43,4 @@ public class AccessToken {
 
   @JsonProperty("id_token")
   private String idToken;
-
-  public PersistedToken toPersistedToken() {
-    return PersistedToken.builder()
-        .userInfo(TokenUtils.userInfo(accessToken))
-        .refreshToken(refreshToken)
-        .expiresIn(expiresIn)
-        .expiresAt(from(now().plusSeconds(expiresIn)))
-        .build();
-  }
 }

--- a/src/main/java/io/okdp/spark/authc/model/PersistedToken.java
+++ b/src/main/java/io/okdp/spark/authc/model/PersistedToken.java
@@ -17,8 +17,10 @@
 package io.okdp.spark.authc.model;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.okdp.spark.authc.provider.IdentityProvider;
 import io.okdp.spark.authc.utils.JsonUtils;
 import java.time.Instant;
 import java.util.Date;
@@ -36,6 +38,9 @@ import lombok.experimental.Accessors;
 @NoArgsConstructor
 public class PersistedToken {
 
+  @JsonProperty("identity_provider")
+  private IdentityProvider identityProvider;
+
   @JsonProperty("access_token_payload")
   private UserInfo userInfo;
 
@@ -49,6 +54,7 @@ public class PersistedToken {
   @JsonProperty("refresh_token")
   private String refreshToken;
 
+  @JsonIgnore
   public boolean isExpired() {
     return Instant.now().isAfter(expiresAt.toInstant());
   }
@@ -56,5 +62,10 @@ public class PersistedToken {
   /** Convert this object to json */
   public String toJson() {
     return JsonUtils.toJson(this);
+  }
+
+  /** Extract the id from UserInfo */
+  public String id() {
+    return identityProvider.extractId(this.userInfo);
   }
 }

--- a/src/main/java/io/okdp/spark/authc/model/UserInfo.java
+++ b/src/main/java/io/okdp/spark/authc/model/UserInfo.java
@@ -18,6 +18,7 @@ package io.okdp.spark.authc.model;
 
 import static java.util.Collections.emptyList;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
@@ -30,6 +31,9 @@ import lombok.experimental.Accessors;
 @Accessors(fluent = true)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class UserInfo {
+
+  @JsonProperty("sub")
+  private String sub;
 
   @JsonProperty("name")
   private String name;
@@ -48,6 +52,7 @@ public class UserInfo {
    *
    * @return the list of the groups or roles
    */
+  @JsonIgnore
   public List<String> getGroupsAndRoles() {
     return Stream.concat(groups.stream(), roles.stream()).collect(Collectors.toList());
   }

--- a/src/main/java/io/okdp/spark/authc/provider/IdentityProvider.java
+++ b/src/main/java/io/okdp/spark/authc/provider/IdentityProvider.java
@@ -1,0 +1,45 @@
+/*
+ *    Copyright 2024 tosit.io
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package io.okdp.spark.authc.provider;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.okdp.spark.authc.model.UserInfo;
+import io.okdp.spark.authc.provider.impl.EmailIdentityProvider;
+import io.okdp.spark.authc.provider.impl.SubIdentityProvider;
+
+@JsonTypeInfo(
+    include = JsonTypeInfo.As.PROPERTY,
+    use = JsonTypeInfo.Id.NAME,
+    property = "type",
+    defaultImpl = EmailIdentityProvider.class)
+@JsonSubTypes({
+  @JsonSubTypes.Type(value = EmailIdentityProvider.class, name = "email"),
+  @JsonSubTypes.Type(value = SubIdentityProvider.class, name = "sub")
+})
+
+/** Each concrete Identity provider should implement this interface */
+public interface IdentityProvider {
+
+  /**
+   * Extract the id form the userInfo ({@link UserInfo})
+   *
+   * @param UserInfo the userInfo extracted from the user's access token
+   * @return the id as a ({@link String})
+   */
+  String extractId(UserInfo userInfo);
+}

--- a/src/main/java/io/okdp/spark/authc/provider/IdentityProviderFactory.java
+++ b/src/main/java/io/okdp/spark/authc/provider/IdentityProviderFactory.java
@@ -1,0 +1,39 @@
+/*
+ *    Copyright 2024 tosit.io
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package io.okdp.spark.authc.provider;
+
+import io.okdp.spark.authc.exception.OidcClientException;
+import java.lang.reflect.InvocationTargetException;
+
+public class IdentityProviderFactory {
+  public static IdentityProvider from(String provider) throws OidcClientException {
+    try {
+      return (IdentityProvider)
+          Class.forName("io.okdp.spark.authc.provider.impl." + provider + "IdentityProvider")
+              .getDeclaredConstructor()
+              .newInstance();
+    } catch (InstantiationException
+        | IllegalAccessException
+        | IllegalArgumentException
+        | InvocationTargetException
+        | NoSuchMethodException
+        | SecurityException
+        | ClassNotFoundException e) {
+      throw new OidcClientException("ID provider not found", e);
+    }
+  }
+}

--- a/src/main/java/io/okdp/spark/authc/provider/SessionStore.java
+++ b/src/main/java/io/okdp/spark/authc/provider/SessionStore.java
@@ -16,8 +16,8 @@
 
 package io.okdp.spark.authc.provider;
 
-import io.okdp.spark.authc.model.AccessToken;
 import io.okdp.spark.authc.model.AuthState;
+import io.okdp.spark.authc.model.PersistedToken;
 
 /** Each concrete token store should implement this interface */
 public interface SessionStore {
@@ -25,10 +25,10 @@ public interface SessionStore {
   /**
    * Save the access token in a {@link T}
    *
-   * @param accessToken the access token response from the oidc provider
+   * @param PersistedToken the persisted token issued from the response from the oidc provider
    * @return {@link T} containing the saved access token
    */
-  <T> T save(AccessToken accessToken);
+  <T> T save(PersistedToken PersistedToken);
 
   /**
    * Save the PKCE state in a {@link T}

--- a/src/main/java/io/okdp/spark/authc/provider/impl/EmailIdentityProvider.java
+++ b/src/main/java/io/okdp/spark/authc/provider/impl/EmailIdentityProvider.java
@@ -14,25 +14,17 @@
  *    limitations under the License.
  */
 
-package io.okdp.spark.authc.config;
+package io.okdp.spark.authc.provider.impl;
 
-import io.okdp.spark.authc.model.WellKnownConfiguration;
+import io.okdp.spark.authc.model.UserInfo;
 import io.okdp.spark.authc.provider.IdentityProvider;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.experimental.Accessors;
+import lombok.NoArgsConstructor;
 
-@Builder
-@Getter
-@Accessors(fluent = true)
-public class OidcConfig {
-  private String issuerUri;
-  private String clientId;
-  private String clientSecret;
-  private String redirectUri;
-  private String responseType;
-  private String scope;
-  private WellKnownConfiguration wellKnownConfiguration;
-  private String usePKCE;
-  private IdentityProvider identityProvider;
+@NoArgsConstructor
+public class EmailIdentityProvider implements IdentityProvider {
+
+  @Override
+  public String extractId(UserInfo userInfo) {
+    return userInfo.email();
+  }
 }

--- a/src/main/java/io/okdp/spark/authc/provider/impl/SubIdentityProvider.java
+++ b/src/main/java/io/okdp/spark/authc/provider/impl/SubIdentityProvider.java
@@ -14,25 +14,17 @@
  *    limitations under the License.
  */
 
-package io.okdp.spark.authc.config;
+package io.okdp.spark.authc.provider.impl;
 
-import io.okdp.spark.authc.model.WellKnownConfiguration;
+import io.okdp.spark.authc.model.UserInfo;
 import io.okdp.spark.authc.provider.IdentityProvider;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.experimental.Accessors;
+import lombok.NoArgsConstructor;
 
-@Builder
-@Getter
-@Accessors(fluent = true)
-public class OidcConfig {
-  private String issuerUri;
-  private String clientId;
-  private String clientSecret;
-  private String redirectUri;
-  private String responseType;
-  private String scope;
-  private WellKnownConfiguration wellKnownConfiguration;
-  private String usePKCE;
-  private IdentityProvider identityProvider;
+@NoArgsConstructor
+public class SubIdentityProvider implements IdentityProvider {
+
+  @Override
+  public String extractId(UserInfo userInfo) {
+    return userInfo.sub();
+  }
 }

--- a/src/main/java/io/okdp/spark/authc/provider/impl/store/CookieSessionStore.java
+++ b/src/main/java/io/okdp/spark/authc/provider/impl/store/CookieSessionStore.java
@@ -59,14 +59,14 @@ public class CookieSessionStore implements SessionStore {
    */
   @Override
   @SuppressWarnings("unchecked")
-  public Cookie save(AccessToken accessToken) {
+  public Cookie save(PersistedToken persistedToken) {
     // Reduce the token size by saving the token payload part only (user info)
     // Compress the access token to overcome 4KB cookie limit (depends on the OIDC providers and
     // their config)
     // Encrypt the content to prevent token corruption
     String cookieValue =
-        ofNullable(accessToken)
-            .map(token -> accessToken.toPersistedToken().toJson())
+        ofNullable(persistedToken)
+            .map(token -> persistedToken.toJson())
             .map(tokenAsJson -> encryptToString(compressToString(tokenAsJson), encryptionKey))
             .orElse("");
 
@@ -114,6 +114,7 @@ public class CookieSessionStore implements SessionStore {
    * @return {@link PersistedToken} containing the access token
    */
   @Override
+  @SuppressWarnings("unchecked")
   public PersistedToken readToken(String value) {
     return JsonUtils.loadJsonFromString(
         CompressionUtils.decompress(EncryptionUtils.decrypt(value, encryptionKey)),
@@ -127,6 +128,7 @@ public class CookieSessionStore implements SessionStore {
    * @return {@link AuthState} containing the PKCE state
    */
   @Override
+  @SuppressWarnings("unchecked")
   public AuthState readPKCEState(String value) {
     return JsonUtils.loadJsonFromString(
         EncryptionUtils.decrypt(value, encryptionKey), AuthState.class);

--- a/src/main/java/io/okdp/spark/authc/utils/TokenUtils.java
+++ b/src/main/java/io/okdp/spark/authc/utils/TokenUtils.java
@@ -28,4 +28,11 @@ public class TokenUtils implements Constants {
     return JsonUtils.loadJsonFromString(
         new String(BASE64_DECODER.decode(parts[1])), UserInfo.class);
   }
+
+  /** Upper case for first letter and lower case fo remaining letter */
+  public static String capitalize(String str) {
+    if (str == null) return str;
+    if (str.length() <= 1) return str.toUpperCase();
+    return str.substring(0, 1).toUpperCase() + str.substring(1).toLowerCase();
+  }
 }

--- a/src/test/java/io/okdp/spark/authc/OidcAuthFilterTest.java
+++ b/src/test/java/io/okdp/spark/authc/OidcAuthFilterTest.java
@@ -17,9 +17,11 @@
 package io.okdp.spark.authc;
 
 import static java.lang.String.format;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 import static scala.collection.JavaConverters.asScalaSet;
 
@@ -99,6 +101,7 @@ public class OidcAuthFilterTest implements Constants, CommonTest {
       when(filterConfig.getInitParameter(AUTH_COOKIE_ENCRYPTION_KEY))
           .thenReturn(cookieEncryptionKey);
       when(filterConfig.getInitParameter(AUTH_USE_PKCE)).thenReturn("false");
+      when(filterConfig.getInitParameter(AUTH_USER_ID)).thenReturn("email");
       oidcAuthFilter.init(filterConfig);
     }
 


### PR DESCRIPTION
feat[oidc] : option to choose the id from the JWT used for identification inside spark UI and spark history (default is email)

One can implement IdentityProvider interface to add new id (truncating email, relying on name, mixing fields, ...)
Added a new parameter `user-id` to specify the IdentityProvider to use (email or sub). Default value is email (for non breaking change)
Move toPersistedToken method to HttpSecurityContext to inject the IdentityProvider implementation inside. 