### PR TITLE
fix: accept single values for group and roles

### DIFF
--- a/src/main/java/io/okdp/spark/authc/model/UserInfo.java
+++ b/src/main/java/io/okdp/spark/authc/model/UserInfo.java
@@ -18,6 +18,7 @@ package io.okdp.spark.authc.model;
 
 import static java.util.Collections.emptyList;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -44,9 +45,11 @@ public class UserInfo {
   private String email;
 
   @JsonProperty("groups")
+  @JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
   private List<String> groups = emptyList();
 
   @JsonProperty("roles")
+  @JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
   private List<String> roles = emptyList();
 
   /**

--- a/src/test/java/io/okdp/spark/authc/utils/JsonUtilsTest.java
+++ b/src/test/java/io/okdp/spark/authc/utils/JsonUtilsTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.okdp.spark.authc.common.CommonTest;
 import io.okdp.spark.authc.model.AccessToken;
+import io.okdp.spark.authc.model.UserInfo;
 import io.okdp.spark.authc.model.WellKnownConfiguration;
 import org.junit.jupiter.api.Test;
 
@@ -56,5 +57,39 @@ public class JsonUtilsTest implements CommonTest {
     assertThat(token.refreshToken())
         .isEqualTo("ChlvaWJmNXBuaG1rdWN0enppaGltaWp1MnJkEhlndmdzZ2tmcnVhd2x6cGV1a2ZnajNqdjJr");
     assertThat(token.tokenType()).isEqualTo("bearer");
+  }
+
+  @Test
+  public void should_parse_single_value_groups_and_roles() {
+    String userInfoJson =
+        "{\n"
+            + "  \"sub\": \"sImtpZCI6IjBkZWEwOTM\",\n"
+            + "  \"name\": \"user\",\n"
+            + "  \"email\": user@example.org,\n"
+            + "  \"groups\": \"group1\",\n"
+            + "  \"roles\": \"role1\"\n"
+            + "}";
+
+    UserInfo userInfo = JsonUtils.loadJsonFromString(userInfoJson, UserInfo.class);
+
+    assertThat(userInfo.groups()).containsOnly("group1");
+    assertThat(userInfo.roles()).containsOnly("role1");
+  }
+
+  @Test
+  public void should_parse_multiple_value_groups_and_roles() {
+    String userInfoJson =
+        "{\n"
+            + "  \"sub\": \"sImtpZCI6IjBkZWEwOTM\",\n"
+            + "  \"name\": \"user\",\n"
+            + "  \"email\": user@example.org,\n"
+            + "  \"groups\": [\"group1\", \"group2\"],\n"
+            + "  \"roles\": [\"role1\", \"role2\"]\n"
+            + "}";
+
+    UserInfo userInfo = JsonUtils.loadJsonFromString(userInfoJson, UserInfo.class);
+
+    assertThat(userInfo.groups()).containsExactly("group1", "group2");
+    assertThat(userInfo.roles()).containsExactly("role1", "role2");
   }
 }

--- a/src/test/java/io/okdp/spark/authc/utils/JsonUtilsTest.java
+++ b/src/test/java/io/okdp/spark/authc/utils/JsonUtilsTest.java
@@ -65,7 +65,7 @@ public class JsonUtilsTest implements CommonTest {
         "{\n"
             + "  \"sub\": \"sImtpZCI6IjBkZWEwOTM\",\n"
             + "  \"name\": \"user\",\n"
-            + "  \"email\": user@example.org,\n"
+            + "  \"email\": \"user@example.org\",\n"
             + "  \"groups\": \"group1\",\n"
             + "  \"roles\": \"role1\"\n"
             + "}";
@@ -82,7 +82,7 @@ public class JsonUtilsTest implements CommonTest {
         "{\n"
             + "  \"sub\": \"sImtpZCI6IjBkZWEwOTM\",\n"
             + "  \"name\": \"user\",\n"
-            + "  \"email\": user@example.org,\n"
+            + "  \"email\": \"user@example.org\",\n"
             + "  \"groups\": [\"group1\", \"group2\"],\n"
             + "  \"roles\": [\"role1\", \"role2\"]\n"
             + "}";


### PR DESCRIPTION
I faced an issue where the OIDC provider is returning a single role or a single group for user as a single value instead of an array and deserialization is failing. This would treat single values an one element array.