### PR TITLE
fix: add Content-Type header before redirecting to auth URL

### DIFF
--- a/src/main/java/io/okdp/spark/authc/OidcAuthFilter.java
+++ b/src/main/java/io/okdp/spark/authc/OidcAuthFilter.java
@@ -412,6 +412,7 @@ public class OidcAuthFilter implements Filter, Constants {
           persistedToken.id(), persistedToken.userInfo().getGroupsAndRoles());
       // Redirect the user from the browser (client) side into spark/history UI home page (i.e.
       // remove the authz 'code' from the browser)
+      servletResponse.setContentType("text/html;charset=UTF-8");
       servletResponse
           .getWriter()
           .print(

--- a/src/main/java/io/okdp/spark/authc/provider/impl/PKCEAuthorizationCodeAuthProvider.java
+++ b/src/main/java/io/okdp/spark/authc/provider/impl/PKCEAuthorizationCodeAuthProvider.java
@@ -81,6 +81,7 @@ public class PKCEAuthorizationCodeAuthProvider extends AbstractAuthorizationCode
     try {
       Cookie cookie = httpSecurityConfig.sessionStore().save(authState);
       ((HttpServletResponse) servletResponse).addCookie(cookie);
+      servletResponse.setContentType("text/html;charset=UTF-8");
       servletResponse
           .getWriter()
           .print(


### PR DESCRIPTION
### What this PR does

This pull request adds an explicit `Content-Type: text/html;charset=UTF-8` header before returning JavaScript-based HTML redirects in the OIDC authentication flow.

### Problem

Currently, when a user is redirected to the OIDC authorization endpoint or returned back to the Spark UI with a `code` parameter, the application responds with an HTML body that contains a JavaScript-based redirect like this:

```html
<script type="text/javascript">window.location.href = '...'</script>
```
However, the response does not include a Content-Type header, which causes issues in environments where:

- X-Content-Type-Options: nosniff is set
- JavaScript is disabled
- Browsers are more strict about content type detection (e.g., legacy Edge, IE, iframe contexts)

In such cases, the browser treats the response as text/plain, and instead of redirecting, it displays the script as plain text, breaking the login flow.


