### PR TITLE
fix java 8 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -328,6 +328,10 @@
                   <pattern>com.google.common</pattern>
                   <shadedPattern>io.okdp_shaded.com.google.common</shadedPattern>
                 </relocation>
+                <relocation>
+                  <pattern>com.nimbusds</pattern>
+                  <shadedPattern>io.okdp_shaded.com.nimbusds</shadedPattern>
+                </relocation>
               </relocations>
             </configuration>
           </execution>

--- a/src/main/java/io/okdp/spark/authc/OidcAuthFilter.java
+++ b/src/main/java/io/okdp/spark/authc/OidcAuthFilter.java
@@ -154,10 +154,10 @@ public class OidcAuthFilter implements Filter, Constants {
 
     Optional<String> jwtHeaderIssuer =
         ofNullable(filterConfig.getInitParameter(JWT_HEADER_ISSUER))
-            .or(() -> ofNullable(System.getenv("JWT_HEADER_ISSUER")));
+            .orElse(ofNullable(System.getenv("JWT_HEADER_ISSUER")));
     Optional<String> jwtHeaderJWKSUri =
         ofNullable(filterConfig.getInitParameter(JWT_HEADER_JWKS_URI))
-            .or(() -> ofNullable(System.getenv("JWT_HEADER_JWKS_URI")));
+            .orElse(ofNullable(System.getenv("JWT_HEADER_JWKS_URI")));
 
     log.info(
         "Initializing OIDC Auth filter ({}: <{}>,  {}: <{}>,  {}: <{}>,  {}: <{}>,) ...",

--- a/src/main/java/io/okdp/spark/authc/provider/impl/store/CookieSessionStore.java
+++ b/src/main/java/io/okdp/spark/authc/provider/impl/store/CookieSessionStore.java
@@ -21,6 +21,7 @@ import static io.okdp.spark.authc.utils.CompressionUtils.compressToString;
 import static io.okdp.spark.authc.utils.EncryptionUtils.encryptToString;
 import static java.util.Optional.ofNullable;
 
+import com.google.common.base.Strings;
 import io.okdp.spark.authc.model.AccessToken;
 import io.okdp.spark.authc.model.AuthState;
 import io.okdp.spark.authc.model.PersistedToken;
@@ -73,7 +74,10 @@ public class CookieSessionStore implements SessionStore {
             .orElse("");
 
     int maxAge =
-        Optional.of(cookieValue).filter(v -> !v.isBlank()).map(v -> cookieMaxAgeSeconds).orElse(0);
+        Optional.of(cookieValue)
+            .filter(v -> !Strings.isNullOrEmpty(v))
+            .map(v -> cookieMaxAgeSeconds)
+            .orElse(0);
 
     return CookieFactory.of(cookieName, cookieValue, cookieDomain, isSecure, maxAge).newCookie();
   }
@@ -99,7 +103,8 @@ public class CookieSessionStore implements SessionStore {
             .map(state -> encryptToString(state, encryptionKey))
             .orElse("");
 
-    int maxAge = Optional.of(cookieValue).filter(v -> !v.isBlank()).map(v -> 5 * 60).orElse(0);
+    int maxAge =
+        Optional.of(cookieValue).filter(v -> !Strings.isNullOrEmpty(v)).map(v -> 5 * 60).orElse(0);
 
     Cookie cookie =
         CookieFactory.of(AUTH_STATE_COOKE_NAME, cookieValue, cookieDomain, isSecure, maxAge)

--- a/src/main/java/io/okdp/spark/authc/utils/CompressionUtils.java
+++ b/src/main/java/io/okdp/spark/authc/utils/CompressionUtils.java
@@ -18,6 +18,7 @@ package io.okdp.spark.authc.utils;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
+import com.google.common.io.ByteStreams;
 import io.okdp.spark.authc.config.Constants;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -53,7 +54,7 @@ public class CompressionUtils implements Constants {
       byte[] decoded = BASE64_DECODER.decode(base64Compressed.getBytes(UTF_8));
       ByteArrayInputStream in = new ByteArrayInputStream(decoded);
       GZIPInputStream gunzip = new GZIPInputStream(in);
-      return new String(gunzip.readAllBytes(), UTF_8);
+      return new String(ByteStreams.toByteArray(gunzip), UTF_8);
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/src/main/java/io/okdp/spark/authc/utils/HttpAuthenticationUtils.java
+++ b/src/main/java/io/okdp/spark/authc/utils/HttpAuthenticationUtils.java
@@ -18,6 +18,7 @@ package io.okdp.spark.authc.utils;
 
 import static java.util.Optional.ofNullable;
 
+import com.google.common.base.Strings;
 import io.okdp.spark.authc.config.Constants;
 import io.okdp.spark.authc.exception.AuthenticationException;
 import io.okdp.spark.authc.exception.OidcClientException;
@@ -47,7 +48,9 @@ public class HttpAuthenticationUtils implements Constants {
    * @return the cookie content if the cookie exists or return empty if it does not exist
    */
   public static Optional<String> getCookieValue(String cookieName, ServletRequest request) {
-    return getCookie(cookieName, request).map(Cookie::getValue).filter(v -> !v.isBlank());
+    return getCookie(cookieName, request)
+        .map(Cookie::getValue)
+        .filter(v -> !Strings.isNullOrEmpty(v));
   }
 
   /**

--- a/src/test/java/io/okdp/spark/authc/OidcAuthFilterTest.java
+++ b/src/test/java/io/okdp/spark/authc/OidcAuthFilterTest.java
@@ -17,8 +17,8 @@
 package io.okdp.spark.authc;
 
 import static java.lang.String.format;
+import static java.util.Arrays.asList;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
@@ -37,7 +37,6 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.lang.reflect.Field;
 import java.util.HashSet;
-import java.util.List;
 import javax.servlet.FilterChain;
 import javax.servlet.FilterConfig;
 import javax.servlet.ServletException;
@@ -221,6 +220,6 @@ public class OidcAuthFilterTest implements Constants, CommonTest {
 
     // Then
     assertThat(groupMappingServiceProvider.getGroups("bob@example.org"))
-        .isEqualTo(asScalaSet(new HashSet<>(List.of("superadmins"))).toSet());
+        .isEqualTo(asScalaSet(new HashSet<>(asList("superadmins"))).toSet());
   }
 }

--- a/src/test/java/io/okdp/spark/authc/utils/PreconditionsUtilsTest.java
+++ b/src/test/java/io/okdp/spark/authc/utils/PreconditionsUtilsTest.java
@@ -18,12 +18,12 @@ package io.okdp.spark.authc.utils;
 
 import static io.okdp.spark.authc.utils.PreconditionsUtils.assertSupportePKCE;
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.ThrowableAssert.catchThrowable;
 
 import io.okdp.spark.authc.exception.AuthenticationException;
-import java.util.List;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.Test;
 
@@ -86,16 +86,16 @@ public class PreconditionsUtilsTest {
         () -> assertSupportePKCE(asList("plain", "S256"), "true", null, "client-secret");
 
     ThrowingCallable validConf3 =
-        () -> assertSupportePKCE(List.of(), "true", null, "client-secret");
+        () -> assertSupportePKCE(emptyList(), "true", null, "client-secret");
 
     ThrowingCallable validConf4 =
-        () -> assertSupportePKCE(List.of(), "false", "ClientSecret@", "client-secret");
+        () -> assertSupportePKCE(emptyList(), "false", "ClientSecret@", "client-secret");
 
     ThrowingCallable invalidConf1 =
         () -> assertSupportePKCE(asList("plain", "S256"), "false", null, "client-secret");
 
     ThrowingCallable invalidConf2 =
-        () -> assertSupportePKCE(List.of(), "auto", null, "client-secret");
+        () -> assertSupportePKCE(emptyList(), "auto", null, "client-secret");
 
     // Then
     assertThatCode(validConf1).doesNotThrowAnyException();

--- a/src/test/java/io/okdp/spark/authz/OidcGroupMappingServiceProviderTest.java
+++ b/src/test/java/io/okdp/spark/authz/OidcGroupMappingServiceProviderTest.java
@@ -21,9 +21,7 @@ import static java.util.Collections.emptySet;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static scala.collection.JavaConverters.asScalaSet;
 
-import java.util.Arrays;
 import java.util.HashSet;
-import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class OidcGroupMappingServiceProviderTest {
@@ -36,12 +34,12 @@ public class OidcGroupMappingServiceProviderTest {
 
     // When
     OidcGroupMappingServiceProvider.addUserAndGroups("user1@example.org", asList("team1", "team2"));
-    OidcGroupMappingServiceProvider.addUserAndGroups("user2@example.org", List.of("team2"));
+    OidcGroupMappingServiceProvider.addUserAndGroups("user2@example.org", asList("team2"));
     // Then
     assertThat(groupMappingServiceProvider.getGroups("user1@example.org"))
-        .isEqualTo(asScalaSet(new HashSet<>(Arrays.asList("team1", "team2"))).toSet());
+        .isEqualTo(asScalaSet(new HashSet<>(asList("team1", "team2"))).toSet());
     assertThat(groupMappingServiceProvider.getGroups("user2@example.org"))
-        .isEqualTo(asScalaSet(new HashSet<>(List.of("team2"))).toSet());
+        .isEqualTo(asScalaSet(new HashSet<>(asList("team2"))).toSet());
   }
 
   @Test


### PR DESCRIPTION
Optional.or() method was added in java 9, it breaks the java 8 compatibility
Optional.or() method is replaced with Optional.orElse()