### PR TITLE
feat: preserve deep-link URL across OIDC authentication flow

### DIFF
--- a/src/main/java/io/okdp/spark/authc/OidcAuthFilter.java
+++ b/src/main/java/io/okdp/spark/authc/OidcAuthFilter.java
@@ -45,7 +45,9 @@ import io.okdp.spark.authc.config.Constants;
 import io.okdp.spark.authc.config.HttpSecurityConfig;
 import io.okdp.spark.authc.config.OidcConfig;
 import io.okdp.spark.authc.exception.AuthenticationException;
+import io.okdp.spark.authc.exception.CipherException;
 import io.okdp.spark.authc.model.AccessToken;
+import io.okdp.spark.authc.model.AuthState;
 import io.okdp.spark.authc.model.PersistedToken;
 import io.okdp.spark.authc.model.WellKnownConfiguration;
 import io.okdp.spark.authc.provider.AuthProvider;
@@ -298,11 +300,22 @@ public class OidcAuthFilter implements Filter, Constants {
     }
 
     // Extract the access token from the http auth cookie if present
-    Optional<String> maybeAuthCookie =
-        HttpAuthenticationUtils.getCookieValue(AUTH_COOKE_NAME, servletRequest);
-    if (maybeAuthCookie.isPresent()) {
-      PersistedToken persistedToken =
-          authProvider.httpSecurityConfig().sessionStore().readToken(maybeAuthCookie.get());
+    Optional<PersistedToken> maybePersistedToken =
+        HttpAuthenticationUtils.getCookieValue(AUTH_COOKE_NAME, servletRequest)
+            .flatMap(
+                value -> {
+                  try {
+                    return Optional.of(
+                        authProvider.httpSecurityConfig().sessionStore().readToken(value));
+                  } catch (CipherException e) {
+                    log.warn(
+                        "Unable to decrypt auth cookie, forcing re-authentication: {}",
+                        e.getMessage());
+                    return Optional.empty();
+                  }
+                });
+    if (maybePersistedToken.isPresent()) {
+      PersistedToken persistedToken = maybePersistedToken.get();
 
       if (persistedToken.isExpired()) {
         AccessToken newAccessToken = null;
@@ -384,12 +397,38 @@ public class OidcAuthFilter implements Filter, Constants {
       // The previous redirect was maybe failed (prevent infinite loop)
       Try.of(() -> checkAuthLogin(servletRequest))
           .onException(e -> sendError(servletResponse, e.getHttpStatusCode(), e.getMessage()));
-      // Redirect the user to the oidc provider to authenticate at the first time access to spark
-      // UI/History
-      authProvider.redirectUserToAuthorizationEndpoint(servletResponse);
+      // Capture the original URL (path + query) so that, after the OIDC round-trip, the user is
+      // redirected back to the exact deep-link they first requested (e.g. /history/<appId>/jobs/).
+      // The return URL is carried inside the encrypted, short-lived state cookie next to the PKCE
+      // code_verifier, which is reliable across the cross-origin hop to the OIDC provider (unlike
+      // sessionStorage, which some browsers partition for cross-site navigations).
+      HttpServletRequest httpReq = (HttpServletRequest) servletRequest;
+      String originalUrl = httpReq.getRequestURI();
+      if (httpReq.getQueryString() != null) {
+        originalUrl += "?" + httpReq.getQueryString();
+      }
+      authProvider.redirectUserToAuthorizationEndpoint(servletResponse, originalUrl);
     } else {
       // The user is authenticated and redirected by the oidc provider into the application with a
       // 'code' query parameter (?code=...)
+      // Read the original return URL from the state cookie BEFORE it gets cleared by
+      // requestAccessToken so we can redirect the user to their initial deep-link.
+      String returnUrl =
+          HttpAuthenticationUtils.getCookieValue(AUTH_STATE_COOKE_NAME, servletRequest)
+              .flatMap(
+                  value -> {
+                    try {
+                      return Optional.<AuthState>of(
+                          authProvider.httpSecurityConfig().sessionStore().readPKCEState(value));
+                    } catch (CipherException e) {
+                      log.warn("Unable to decrypt state cookie: {}", e.getMessage());
+                      return Optional.empty();
+                    }
+                  })
+              .map(AuthState::returnUrl)
+              .filter(u -> u != null && !u.isEmpty())
+              .orElse("/");
+
       // Exchange the obtained 'code' with an access token by issuing a request against the oidc
       // provider
       AccessToken accessToken =
@@ -421,15 +460,8 @@ public class OidcAuthFilter implements Filter, Constants {
       // Add the user and groups in the user/group mappings authorization cache
       OidcGroupMappingServiceProvider.addUserAndGroups(
           persistedToken.id(), persistedToken.userInfo().getGroupsAndRoles());
-      // Redirect the user from the browser (client) side into spark/history UI home page (i.e.
-      // remove the authz 'code' from the browser)
-      servletResponse.setContentType("text/html;charset=UTF-8");
-      servletResponse
-          .getWriter()
-          .print(
-              String.format(
-                  "<script type=\"text/javascript\">window.location.href = '%s'</script>",
-                  ((HttpServletRequest) servletRequest).getRequestURI()));
+      // Redirect to the original deep-link captured in the state cookie
+      ((HttpServletResponse) servletResponse).sendRedirect(returnUrl);
     }
   }
 

--- a/src/main/java/io/okdp/spark/authc/model/AuthState.java
+++ b/src/main/java/io/okdp/spark/authc/model/AuthState.java
@@ -47,6 +47,9 @@ public class AuthState {
   @JsonProperty("code_challenge")
   private String codeChallenge;
 
+  @JsonProperty("return_url")
+  private String returnUrl;
+
   /** Converts this object to json string */
   public String toJson() {
     return JsonUtils.toJson(this);
@@ -58,10 +61,21 @@ public class AuthState {
    * code_challenge: derived from the code_verifier
    */
   public static AuthState randomState() {
+    return randomState(null);
+  }
+
+  /**
+   * Generates a random state carrying the original request URL so that, after a successful OIDC
+   * round-trip, the filter can redirect the user to the exact deep-link they initially requested
+   * (e.g. {@code /history/<appId>/jobs/}). Per-tab correctness is achieved by encoding the URL in
+   * the encrypted, short-lived state cookie (the sessionStorage approach is unreliable across the
+   * cross-origin hop to the OIDC provider on browsers that partition storage).
+   */
+  public static AuthState randomState(String returnUrl) {
     String state = randomString(16);
     String codeVerifier = randomString(64);
     String codeChallenge = createCodeChallenge(codeVerifier);
-    return new AuthState(state, codeVerifier, codeChallenge);
+    return new AuthState(state, codeVerifier, codeChallenge, returnUrl);
   }
 
   /** Generates a random PKCE code_verifier as stated */

--- a/src/main/java/io/okdp/spark/authc/provider/AuthProvider.java
+++ b/src/main/java/io/okdp/spark/authc/provider/AuthProvider.java
@@ -30,7 +30,21 @@ public interface AuthProvider {
    * @param servletResponse the {@link ServletResponse}
    * @throws AuthenticationException
    */
-  void redirectUserToAuthorizationEndpoint(ServletResponse servletResponse)
+  default void redirectUserToAuthorizationEndpoint(ServletResponse servletResponse)
+      throws AuthenticationException {
+    redirectUserToAuthorizationEndpoint(servletResponse, null);
+  }
+
+  /**
+   * Redirect the user to the OIDC provider while preserving the original request URL so that the
+   * user is taken back to the exact deep-link they first requested once authenticated.
+   *
+   * @param servletResponse the {@link ServletResponse}
+   * @param returnUrl the original request URL (path + query) to redirect the user to after the OIDC
+   *     round-trip; may be {@code null} or {@code /} to go to the application root
+   * @throws AuthenticationException
+   */
+  void redirectUserToAuthorizationEndpoint(ServletResponse servletResponse, String returnUrl)
       throws AuthenticationException;
 
   /**

--- a/src/main/java/io/okdp/spark/authc/provider/impl/DefaultAuthorizationCodeAuthProvider.java
+++ b/src/main/java/io/okdp/spark/authc/provider/impl/DefaultAuthorizationCodeAuthProvider.java
@@ -57,7 +57,7 @@ public class DefaultAuthorizationCodeAuthProvider extends AbstractAuthorizationC
   }
 
   @Override
-  public void redirectUserToAuthorizationEndpoint(ServletResponse servletResponse)
+  public void redirectUserToAuthorizationEndpoint(ServletResponse servletResponse, String returnUrl)
       throws AuthenticationException {
     String authzUrl =
         format(

--- a/src/main/java/io/okdp/spark/authc/provider/impl/PKCEAuthorizationCodeAuthProvider.java
+++ b/src/main/java/io/okdp/spark/authc/provider/impl/PKCEAuthorizationCodeAuthProvider.java
@@ -64,9 +64,9 @@ public class PKCEAuthorizationCodeAuthProvider extends AbstractAuthorizationCode
   }
 
   @Override
-  public void redirectUserToAuthorizationEndpoint(ServletResponse servletResponse)
+  public void redirectUserToAuthorizationEndpoint(ServletResponse servletResponse, String returnUrl)
       throws AuthenticationException {
-    AuthState authState = AuthState.randomState();
+    AuthState authState = AuthState.randomState(returnUrl);
     String authzUrl =
         format(
             "%s?client_id=%s&redirect_uri=%s&response_type=%s&scope=%s&state=%s&code_challenge=%s&code_challenge_method=S256",

--- a/src/main/java/io/okdp/spark/authc/provider/impl/store/CookieSessionStore.java
+++ b/src/main/java/io/okdp/spark/authc/provider/impl/store/CookieSessionStore.java
@@ -157,7 +157,7 @@ public class CookieSessionStore implements SessionStore {
       cookie.setDomain(cookieDomain);
       cookie.setHttpOnly(true);
       cookie.setSecure(isSecure);
-      cookie.setPath("/;SameSite=Strict;");
+      cookie.setPath("/;SameSite=Lax;");
       return cookie;
     }
   }

--- a/src/test/java/io/okdp/spark/authc/OidcAuthFilterTest.java
+++ b/src/test/java/io/okdp/spark/authc/OidcAuthFilterTest.java
@@ -131,6 +131,24 @@ public class OidcAuthFilterTest implements Constants, CommonTest {
   }
 
   @Test
+  void should_force_reauthentication_when_auth_cookie_is_corrupted()
+      throws IOException, ServletException {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    FilterChain chain = mock(FilterChain.class);
+    when(request.getRequestURI()).thenReturn("/home");
+    Cookie corrupted = new Cookie(AUTH_COOKE_NAME, "not-a-valid-ciphertext");
+    when(request.getCookies()).thenReturn(new Cookie[] {corrupted});
+
+    oidcAuthFilter.doFilter(request, response, chain);
+
+    verify(chain, never()).doFilter(request, response);
+    ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+    verify(response).sendRedirect(captor.capture());
+    assertThat(captor.getValue()).startsWith("https://dex.okdp.local/dex/auth?");
+  }
+
+  @Test
   void should_run_authentication_flow_authc__on_first_login() throws IOException, ServletException {
     // Given
     HttpServletRequest request = mock(HttpServletRequest.class);
@@ -141,9 +159,11 @@ public class OidcAuthFilterTest implements Constants, CommonTest {
     // When
     oidcAuthFilter.doFilter(request, response, chain);
 
-    // Then - Redirect the user to login and callback with the authz code
-    ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+    // Then - Redirect the user to the OIDC authorization endpoint. With the default (non-PKCE)
+    // provider, the deep-link return URL is not persisted server-side (no state cookie), so the
+    // request is a plain 302 to the authorization endpoint.
     verify(chain, never()).doFilter(request, response);
+    ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
     verify(response).sendRedirect(captor.capture());
     assertEquals(
         format(
@@ -162,8 +182,6 @@ public class OidcAuthFilterTest implements Constants, CommonTest {
     HttpServletResponse response = mock(HttpServletResponse.class);
     FilterChain chain = mock(FilterChain.class);
     when(request.getRequestURI()).thenReturn("/home");
-    StringWriter out = new StringWriter();
-    when(response.getWriter()).thenReturn(new PrintWriter(out));
     // Set the authZ code request parameter
     when(request.getParameter(any(String.class))).thenReturn("kpxblxm2si3x6ofxufgo54h4j");
     // Return the access token from code
@@ -182,9 +200,11 @@ public class OidcAuthFilterTest implements Constants, CommonTest {
             .readToken(captor.getValue().getValue());
     assertNotNull(persistedToken);
 
-    // Then
-    assertThat(out.toString())
-        .isEqualTo("<script type=\"text/javascript\">window.location.href = '/home'</script>");
+    // Then - With the default (non-PKCE) provider there is no state cookie carrying the original
+    // return URL, so the post-callback redirect falls back to the application root.
+    ArgumentCaptor<String> redirectCaptor = ArgumentCaptor.forClass(String.class);
+    verify(response).sendRedirect(redirectCaptor.capture());
+    assertEquals("/", redirectCaptor.getValue());
   }
 
   @Test

--- a/src/test/java/io/okdp/spark/authc/model/AuthStateTest.java
+++ b/src/test/java/io/okdp/spark/authc/model/AuthStateTest.java
@@ -32,5 +32,38 @@ public class AuthStateTest {
     assertThat(authState.state()).isNotBlank();
     assertThat(authState.codeVerifier().length()).isBetween(43, 128);
     assertThat(authState.codeVerifier()).isASCII();
+    assertThat(authState.returnUrl()).isNull();
+  }
+
+  @Test
+  public void should_carry_return_url_through_oidc_roundtrip() {
+    // Given a deep-link URL the user initially requested (e.g. a Spark History Server job page)
+    String returnUrl = "/history/spark-abc123/jobs/";
+
+    // When
+    AuthState authState = AuthState.randomState(returnUrl);
+
+    // Then - the return URL is preserved alongside the PKCE state so the filter can redirect the
+    // user back to their original deep-link after a successful OIDC authentication
+    assertThat(authState.state()).isNotBlank();
+    assertThat(authState.codeVerifier().length()).isBetween(43, 128);
+    assertThat(authState.returnUrl()).isEqualTo(returnUrl);
+  }
+
+  @Test
+  public void should_survive_json_serialization_with_return_url() {
+    // Given
+    AuthState original = AuthState.randomState("/history/spark-xyz/stages/");
+
+    // When - the state is serialized to JSON (how it is stored in the encrypted state cookie)
+    String json = original.toJson();
+    AuthState restored =
+        io.okdp.spark.authc.utils.JsonUtils.loadJsonFromString(json, AuthState.class);
+
+    // Then - every field, including the return URL, round-trips through JSON
+    assertThat(restored.state()).isEqualTo(original.state());
+    assertThat(restored.codeVerifier()).isEqualTo(original.codeVerifier());
+    assertThat(restored.codeChallenge()).isEqualTo(original.codeChallenge());
+    assertThat(restored.returnUrl()).isEqualTo(original.returnUrl());
   }
 }

--- a/src/test/java/io/okdp/spark/authc/provider/store/CookieFactoryStoreTest.java
+++ b/src/test/java/io/okdp/spark/authc/provider/store/CookieFactoryStoreTest.java
@@ -130,7 +130,7 @@ public class CookieFactoryStoreTest {
     assertThat(cookie.getMaxAge()).isEqualTo(60);
     assertThat(cookie.isHttpOnly()).isEqualTo(true);
     assertThat(cookie.getSecure()).isEqualTo(true);
-    assertThat(cookie.getPath()).isEqualTo("/;SameSite=Strict;");
+    assertThat(cookie.getPath()).isEqualTo("/;SameSite=Lax;");
     assertThat(persistedToken.refreshToken()).isEqualTo(accessToken.refreshToken());
     assertThat(persistedToken.expiresIn()).isEqualTo(accessToken.expiresIn());
     assertThat(persistedToken.expiresAt())
@@ -168,7 +168,7 @@ public class CookieFactoryStoreTest {
     assertThat(cookie.getMaxAge()).isEqualTo(60);
     assertThat(cookie.isHttpOnly()).isEqualTo(true);
     assertThat(cookie.getSecure()).isEqualTo(true);
-    assertThat(cookie.getPath()).isEqualTo("/;SameSite=Strict;");
+    assertThat(cookie.getPath()).isEqualTo("/;SameSite=Lax;");
     assertThat(persistedToken.refreshToken()).isEmpty();
     assertThat(persistedToken.hasRefreshToken()).isFalse();
     assertThat(persistedToken.expiresIn()).isEqualTo(accessToken.expiresIn());


### PR DESCRIPTION
Hello @idirze ,

This PR is the proposed fix for the issue I opened in #98 — sharing it with you since you maintain the filter. Happy to iterate on anything you want changed 🙂

Closes #98

## What this changes

### Deep-link preservation (the main fix)

I preserve the user's original URL across the OIDC round-trip so that, after login, they land on the URL they actually clicked instead of the application root.

The mechanism is the existing encrypted PKCE state cookie (`OKDP_AUTH_SPARK_UI_STATE`), which already travels through the IdP round-trip, so no new storage or configuration is needed:

- `AuthState` gets a `returnUrl` field alongside the PKCE `code_verifier`.
- `AuthProvider.redirectUserToAuthorizationEndpoint(...)` accepts the original URL and passes it to `AuthState.randomState(returnUrl)`.
- `OidcAuthFilter.doFilter()` captures `requestURI + ?queryString` before the IdP redirect, reads it back from the state cookie on the callback branch (before `requestAccessToken` clears the cookie), and does `HttpServletResponse.sendRedirect(returnUrl)` with `/` as fallback.

I originally tried browser `sessionStorage` but dropped it: some browsers partition `sessionStorage` across the cross-site OIDC hop, which made the read unreliable in practice. Keeping the return URL in the encrypted state cookie avoids that and replaces the client-side JS redirect with a plain HTTP 302.

### Two related fixes I bundled in

While validating the change end-to-end I hit two pre-existing issues that felt worth fixing in the same scope. Happy to split them out if you'd rather have them as separate PRs.

**1. Graceful handling of `CipherException` on cookie decrypt.**  When `OKDP_AUTH_SPARK_UI` or `OKDP_AUTH_SPARK_UI_STATE` can't be decrypted (key rotation, stale cookies from a previous deployment, corruption), the filter currently returns HTTP 500. I wrapped `readToken` and `readPKCEState` in `OidcAuthFilter` with `try/catch (CipherException)` that logs a warning and treats the cookie as absent, so the user gets a clean re-authentication flow instead.

**2. `SameSite=Strict` → `SameSite=Lax` on the auth cookie.**  `Strict` blocks the cookie on the callback navigation coming from the IdP, which caused infinite authentication loops for me on Safari and on Chrome incognito. `Lax` allows the top-level GET navigation back from the IdP while still blocking cross-site POST and iframe requests. CSRF stays protected via the OAuth `state` parameter that's already validated server-side.

## Tests

Updated `AuthStateTest`, `OidcAuthFilterTest`, and `CookieFactoryStoreTest` to reflect the new behaviour, plus a new `should_force_reauthentication_when_auth_cookie_is_corrupted` covering the CipherException path.

Let me know if you want me to adjust anything — thanks in advance for the review!
