### PR TITLE
ci: harden GitHub Actions security and add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,65 @@
+#
+# Copyright 2026 The OKDP Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+version: 2
+
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Paris"
+    open-pull-requests-limit: 10
+    groups:
+      maven-plugins:
+        patterns:
+          - "*:*plugin*"
+      maven-dependencies:
+        dependency-type: "production"
+        patterns:
+          - "*"
+      maven-test-dependencies:
+        dependency-type: "development"
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:30"
+      timezone: "Europe/Paris"
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "docker-compose"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "07:00"
+      timezone: "Europe/Paris"
+    open-pull-requests-limit: 5
+    groups:
+      docker-compose:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,7 +24,7 @@ updates:
       day: "monday"
       time: "06:00"
       timezone: "Europe/Paris"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 0
     groups:
       maven-plugins:
         patterns:
@@ -45,7 +45,7 @@ updates:
       day: "monday"
       time: "06:30"
       timezone: "Europe/Paris"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 0
     groups:
       github-actions:
         patterns:
@@ -58,7 +58,7 @@ updates:
       day: "monday"
       time: "07:00"
       timezone: "Europe/Paris"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 0
     groups:
       docker-compose:
         patterns:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,10 +49,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo ⚡️
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Set up JDK 11 📦
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'zulu'
           java-version: '11'
@@ -65,14 +67,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo ⚡️
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Set up JDK 11 📦
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'zulu'
           java-version: '11'
 
       - name: Run tests ✅
         run: mvn -ntp test
-

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -24,8 +24,7 @@ on:
       - main
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 # https://docs.github.com/en/actions/using-jobs/using-concurrency
 concurrency:
@@ -40,6 +39,9 @@ defaults:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     outputs:
       release_created: ${{ steps.release-please.outputs.release_created }}
       tag_name: ${{ steps.release-please.outputs.tag_name }}
@@ -47,25 +49,28 @@ jobs:
     # The pull request should come from the same repo (github_token from the fork does not have write permissions)
     if: github.repository_owner == 'OKDP' && github.event.pull_request.merged == true && github.event.pull_request.head.repo.full_name == github.repository
     steps:
-      - uses: google-github-actions/release-please-action@v4
+      - uses: google-github-actions/release-please-action@e4dc86ba9405554aeba3c6bb2d169500e7d3b4ee # v4.1.1
         id: release-please
 
   publish-maven-central:
     runs-on: ubuntu-latest
     needs: [release-please]
+    permissions:
+      contents: read
     if: github.repository_owner == 'OKDP' && needs.release-please.outputs.release_created == 'true'
     steps:
       - name: Checkout Repo ⚡️
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           fetch-tags: true
+          persist-credentials: false
 
       - name: Set up GitHub Actions git bot 📦
         uses: ./.github/actions/setup-git-bot
 
       - name: Set up JDK 11 📦
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'zulu'
           java-version: '11'
@@ -85,8 +90,5 @@ jobs:
           CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
           CENTRAL_TOKEN: ${{ secrets.CENTRAL_TOKEN }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-
-
-
 
 


### PR DESCRIPTION
## Description

This PR hardens the repository GitHub Actions workflows and adds Dependabot configuration for dependency updates.

Main changes include:

* Pin GitHub Actions to immutable commit SHAs.
* Disable persisted checkout credentials where they are not needed.
* Reduce default workflow permissions to least privilege.
* Scope write permissions only to jobs that require them.
* Keep release publishing permissions explicit and limited.
* Add Dependabot configuration for (see [OKDP/OKDP#27](https://github.com/OKDP/OKDP/issues/27)):

  * Maven dependencies
  * GitHub Actions
  * Docker Compose dependencies

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Documentation update
* [x] Refactor / chore
* [ ] Breaking change

## Checklist

* [ ] I have tested my changes
* [ ] Documentation updated if needed
* [ ] If breaking change: migration path described above
* [x] I hereby declare this contribution to be licensed under the [[Apache License Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)](http://www.apache.org/licenses/LICENSE-2.0).
* [x] I hereby agree to grant [[TOSIT](https://www.tosit.io/)](https://www.tosit.io/) a copyright license to use my contributions.